### PR TITLE
Prefer executing "python3" than "python" in qlphelper

### DIFF
--- a/src/qlphelper/streamfinder.cpp
+++ b/src/qlphelper/streamfinder.cpp
@@ -61,7 +61,7 @@ void StreamFinder::startRequest()
     QStringList args;
     args.append(QStandardPaths::locate(QStandardPaths::DataLocation, "stream_finder.py"));
     args.append(room_url);
-    proc->start("python", args);
+    proc->start("python3", args);
     QTimer::singleShot(20000, [this, tid]() {
         if (this->proc->state() == QProcess::Running && tid == this->proc_id) {
             this->proc->kill();


### PR DESCRIPTION
Due to some reasons, some distrobutions, for example Debian, has recommended python2 rather than python3 in the alias "_python_". If the qlphelper executing "_python_" in these environments, it will cause the mysterious "**Stream url not found**" problem.
this PR can fix that problem described above.